### PR TITLE
Don't mention cast whitespace

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -273,9 +273,8 @@ void func(int param)
          80 characters long but that they $(I can) exceed 80 characters when
          appropriate. However, they can $(I never) exceed 120 characters.)
 
-    $(LI Put a space after `cast(…)`, `for`, `foreach`, `if`, and `while`: )
+    $(LI Put a space after `for`, `foreach`, `if`, and `while`: )
 -------------------------------
-auto x = cast(…) y;
 for (…) { … }
 foreach (…) { … }
 if (x) { … }


### PR DESCRIPTION
The cast rule is disputed: https://github.com/D-Programming-Language/dlang.org/pull/1191

So let's just not mention it. (Phobos uses both but no space after is more common).
